### PR TITLE
Point hackage back to original source.

### DIFF
--- a/haskell-lexer.cabal
+++ b/haskell-lexer.cabal
@@ -9,6 +9,8 @@ Synopsis:       A fully compliant Haskell 98 lexer.
 Description:    A fully compliant Haskell 98 lexer.
 Build-Depends:  base
 Build-type:     Simple
+Homepage:            https://github.com/yav/haskell-lexer
+Bug-reports:         https://github.com/yav/haskell-lexer/issues
 Extra-source-files: LICENSE
 Exposed-modules:  Language.Haskell.Lexer
 Other-modules:    Language.Haskell.Lexer.Layout,


### PR DESCRIPTION
I found this package on hackage via a colleague and had to search around a bit to find the matching source code.
It would be great if the homepage and bug-reports link pointed back here, which I'm assuming is the canonical source for http://hackage.haskell.org/package/haskell-lexer
