### PR TITLE
Topic/travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,87 @@
+# This file has been generated -- see https://github.com/hvr/multi-ghc-travis
+language: c
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.cabsnap
+    - $HOME/.cabal/packages
+
+before_cache:
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/00-index.tar
+
+matrix:
+  include:
+    - env: CABALVER=1.18 GHCVER=7.8.4
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.2
+      compiler: ": #GHC 8.0.2"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
+    - env: CABALVER=head GHCVER=head
+      compiler: ": #GHC head"
+      addons: {apt: {packages: [cabal-install-head,ghc-head], sources: [hvr-ghc]}}
+
+  allow_failures:
+    - env: CABALVER=head GHCVER=head
+
+before_install:
+ - unset CC
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+
+install:
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - if [ -f $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz ];
+   then
+     zcat $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz >
+          $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
+   fi
+ - travis_retry cabal update -v
+ - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt
+ - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
+
+# check whether current requested install-plan matches cached package-db snapshot
+ - if diff -u $HOME/.cabsnap/installplan.txt installplan.txt;
+   then
+     echo "cabal build-cache HIT";
+     rm -rfv .ghc;
+     cp -a $HOME/.cabsnap/ghc $HOME/.ghc;
+     cp -a $HOME/.cabsnap/lib $HOME/.cabsnap/share $HOME/.cabsnap/bin $HOME/.cabal/;
+   else
+     echo "cabal build-cache MISS";
+     rm -rf $HOME/.cabsnap;
+     mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
+     cabal install --only-dependencies --enable-tests --enable-benchmarks;
+   fi
+
+# snapshot package-db on cache miss
+ - if [ ! -d $HOME/.cabsnap ];
+   then
+      echo "snapshotting package-db to build-cache";
+      mkdir $HOME/.cabsnap;
+      cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
+      cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
+   fi
+
+# Here starts the actual work to be performed for the package under test;
+# any command which exits with a non-zero exit code causes the build to fail.
+script:
+ - if [ -f configure.ac ]; then autoreconf -i; fi
+ - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
+ - cabal build   # this builds all libraries and executables (including tests/benchmarks)
+ - cabal test
+ - cabal sdist   # tests that a source-distribution can be generated
+
+# Check that the resulting source distribution can be built & installed.
+# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
+# `cabal install --force-reinstalls dist/*-*.tar.gz`
+ - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
+   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
+
+# EOF

--- a/Language/Haskell/Lexer/Lex.hs
+++ b/Language/Haskell/Lexer/Lex.hs
@@ -1,7 +1,10 @@
-
 -- Automatically generated code for a DFA follows:
 --Equal states: [[[2,3],[8,9],[5,31],[10,11],[36,37],[39,40]]]
-{-# OPTIONS_GHC -O #-}
+{-# LANGUAGE CPP #-}
+{-# OPTIONS_GHC -O -fno-warn-unused-matches -fno-warn-name-shadowing #-}
+#if __GLASGOW_HASKELL__ > 710
+{-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
+#endif
 module Language.Haskell.Lexer.Lex (haskellLex) where
 import Data.Char
 import Language.Haskell.Lexer.Utils
@@ -5363,5 +5366,3 @@ state213 err as is = nestedComment as is state214
 
 state214 :: LexerState
 state214 err as is = output NestedComment as (start1 is)
-
-

--- a/haskell-lexer.cabal
+++ b/haskell-lexer.cabal
@@ -8,13 +8,14 @@ Category:       Language
 Synopsis:       A fully compliant Haskell 98 lexer.
 Description:    A fully compliant Haskell 98 lexer.
 Build-type:     Simple
-Cabal-version:  >= 1.2
+Cabal-version:  >= 1.6
+Tested-with:    GHC >= 7.8
 
 Homepage:            https://github.com/yav/haskell-lexer
 Bug-reports:         https://github.com/yav/haskell-lexer/issues
 
 Library
-  Build-Depends:  base
+  Build-Depends:  base >= 4.7 && < 5.0
   Exposed-modules:  Language.Haskell.Lexer
   Other-modules:    Language.Haskell.Lexer.Layout,
                     Language.Haskell.Lexer.Tokens,


### PR DESCRIPTION
Adds a travis ci build config.

Also pulls in some other perhaps questionable changes like:
 - GHC supported ranges, I went with 7.8, 7.10, 8.0 and head (easy to change for more if further backwards compatibility is required)
 - version range on base (cabal check encouraged having such a range)
 - silencing warnings and some CPP
 - removing `-02`and bumping cabal version range, again cabal check encouraged this.


Dropping the running of `cabal check` might remove the need to do some of these things.