### PR TITLE
Support for lexing quasi-quotes

### DIFF
--- a/Language/Haskell/Lexer/Lex.hs
+++ b/Language/Haskell/Lexer/Lex.hs
@@ -1,5 +1,6 @@
+
 -- Automatically generated code for a DFA follows:
---Equal states: [[[2,3],[8,9],[5,31],[10,11],[36,37],[39,40]]]
+--Equal states: [[[2,3],[8,9],[166,167],[220,221],[5,31],[10,11],[36,37],[39,40]]]
 {-# OPTIONS_GHC -O #-}
 module Language.Haskell.Lexer.Lex (haskellLex) where
 import Data.Char
@@ -85,45 +86,45 @@ cclass c =
     'X' -> 45
     'Y' -> 46
     '[' -> 47
-    ']' -> 47
     '\\' -> 48
-    '^' -> 49
-    '_' -> 50
-    'a' -> 51
-    'b' -> 52
-    'c' -> 53
-    'd' -> 54
-    'e' -> 55
-    'f' -> 56
-    'g' -> 57
-    'h' -> 58
-    'i' -> 59
-    'j' -> 60
-    'k' -> 60
-    'q' -> 60
-    'z' -> 60
-    'l' -> 61
-    'm' -> 62
-    'n' -> 63
-    'o' -> 64
-    'p' -> 65
-    'r' -> 66
-    's' -> 67
-    't' -> 68
-    'u' -> 69
-    'v' -> 70
-    'w' -> 71
-    'x' -> 72
-    'y' -> 73
-    '{' -> 74
-    '|' -> 75
-    '~' -> 75
+    ']' -> 49
+    '^' -> 50
+    '_' -> 51
+    'a' -> 52
+    'b' -> 53
+    'c' -> 54
+    'd' -> 55
+    'e' -> 56
+    'f' -> 57
+    'g' -> 58
+    'h' -> 59
+    'i' -> 60
+    'j' -> 61
+    'k' -> 61
+    'q' -> 61
+    'z' -> 61
+    'l' -> 62
+    'm' -> 63
+    'n' -> 64
+    'o' -> 65
+    'p' -> 66
+    'r' -> 67
+    's' -> 68
+    't' -> 69
+    'u' -> 70
+    'v' -> 71
+    'w' -> 72
+    'x' -> 73
+    'y' -> 74
+    '{' -> 75
+    '|' -> 76
+    '~' -> 77
     c | isAscii c -> 0
       | isSpace c -> 3
       | (\x -> isSymbol x || isPunctuation x) c -> 7
       | isDigit c -> 18
-      | isLower c -> 60
-      | isUpper c -> 76
+      | isLower c -> 61
+      | isUpper c -> 78
       | otherwise -> 0
 
 start1 :: Lexer
@@ -132,19 +133,19 @@ state1 :: LexerState
 state1 err as [] = gotEOF as
 state1 err as iis@(i:is) =
   case cclass i of
-    51 -> state162 err (i:as) is
-    52 -> state162 err (i:as) is
-    56 -> state162 err (i:as) is
-    57 -> state162 err (i:as) is
-    58 -> state162 err (i:as) is
-    60 -> state162 err (i:as) is
-    65 -> state162 err (i:as) is
-    66 -> state162 err (i:as) is
-    67 -> state162 err (i:as) is
-    69 -> state162 err (i:as) is
-    70 -> state162 err (i:as) is
-    72 -> state162 err (i:as) is
-    73 -> state162 err (i:as) is
+    52 -> state273 err (i:as) is
+    53 -> state273 err (i:as) is
+    57 -> state273 err (i:as) is
+    58 -> state273 err (i:as) is
+    59 -> state273 err (i:as) is
+    61 -> state273 err (i:as) is
+    66 -> state273 err (i:as) is
+    67 -> state273 err (i:as) is
+    68 -> state273 err (i:as) is
+    70 -> state273 err (i:as) is
+    71 -> state273 err (i:as) is
+    73 -> state273 err (i:as) is
+    74 -> state273 err (i:as) is
     1 -> state2 err (i:as) is
     2 -> state2 err (i:as) is
     3 -> state2 err (i:as) is
@@ -155,15 +156,16 @@ state1 err as iis@(i:is) =
     9 -> state4 err (i:as) is
     12 -> state4 err (i:as) is
     22 -> state4 err (i:as) is
-    49 -> state4 err (i:as) is
+    50 -> state4 err (i:as) is
     23 -> state79 err (i:as) is
     48 -> state79 err (i:as) is
-    75 -> state79 err (i:as) is
+    76 -> state79 err (i:as) is
+    77 -> state79 err (i:as) is
     16 -> state87 err (i:as) is
     17 -> state87 err (i:as) is
     18 -> state87 err (i:as) is
     11 -> state73 err (i:as) is
-    47 -> state73 err (i:as) is
+    49 -> state73 err (i:as) is
     0 -> err as iis
     8 -> state5 err (i:as) is
     10 -> state41 err (i:as) is
@@ -173,18 +175,19 @@ state1 err as iis@(i:is) =
     19 -> state92 err (i:as) is
     20 -> state95 err (i:as) is
     21 -> state96 err (i:as) is
-    50 -> state161 err (i:as) is
-    53 -> state163 err (i:as) is
-    54 -> state169 err (i:as) is
-    55 -> state182 err (i:as) is
-    59 -> state183 err (i:as) is
-    61 -> state195 err (i:as) is
-    62 -> state196 err (i:as) is
-    63 -> state200 err (i:as) is
-    64 -> state205 err (i:as) is
-    68 -> state206 err (i:as) is
-    71 -> state209 err (i:as) is
-    74 -> state212 err (i:as) is
+    47 -> state161 err (i:as) is
+    51 -> state272 err (i:as) is
+    54 -> state274 err (i:as) is
+    55 -> state280 err (i:as) is
+    56 -> state293 err (i:as) is
+    60 -> state294 err (i:as) is
+    62 -> state306 err (i:as) is
+    63 -> state307 err (i:as) is
+    64 -> state311 err (i:as) is
+    65 -> state316 err (i:as) is
+    69 -> state317 err (i:as) is
+    72 -> state320 err (i:as) is
+    75 -> state323 err (i:as) is
     _ -> state97 err (i:as) is
 
 state2 :: LexerState
@@ -217,8 +220,9 @@ state4 err as iis@(i:is) =
     22 -> state4 err (i:as) is
     23 -> state4 err (i:as) is
     48 -> state4 err (i:as) is
-    49 -> state4 err (i:as) is
-    75 -> state4 err (i:as) is
+    50 -> state4 err (i:as) is
+    76 -> state4 err (i:as) is
+    77 -> state4 err (i:as) is
     _ -> err as iis
   where err _ _ = output Varsym as (start1 iis)
 
@@ -251,13 +255,13 @@ state7 err as iis@(i:is) =
     9 -> state5 err (i:as) is
     10 -> state5 err (i:as) is
     48 -> state5 err (i:as) is
-    51 -> state5 err (i:as) is
     52 -> state5 err (i:as) is
-    56 -> state5 err (i:as) is
-    63 -> state5 err (i:as) is
-    66 -> state5 err (i:as) is
-    68 -> state5 err (i:as) is
-    70 -> state5 err (i:as) is
+    53 -> state5 err (i:as) is
+    57 -> state5 err (i:as) is
+    64 -> state5 err (i:as) is
+    67 -> state5 err (i:as) is
+    69 -> state5 err (i:as) is
+    71 -> state5 err (i:as) is
     1 -> state8 err (i:as) is
     2 -> state8 err (i:as) is
     3 -> state8 err (i:as) is
@@ -282,9 +286,9 @@ state7 err as iis@(i:is) =
     35 -> state28 err (i:as) is
     37 -> state29 err (i:as) is
     41 -> state30 err (i:as) is
-    49 -> state34 err (i:as) is
-    64 -> state35 err (i:as) is
-    72 -> state38 err (i:as) is
+    50 -> state34 err (i:as) is
+    65 -> state35 err (i:as) is
+    73 -> state38 err (i:as) is
     _ -> err as iis
 
 start8 :: Lexer
@@ -560,6 +564,7 @@ state34 err as iis@(i:is) =
     48 -> state5 err (i:as) is
     49 -> state5 err (i:as) is
     50 -> state5 err (i:as) is
+    51 -> state5 err (i:as) is
     _ -> err as iis
 
 start35 :: Lexer
@@ -608,12 +613,12 @@ state38 err as iis@(i:is) =
     27 -> state39 err (i:as) is
     28 -> state39 err (i:as) is
     29 -> state39 err (i:as) is
-    51 -> state39 err (i:as) is
     52 -> state39 err (i:as) is
     53 -> state39 err (i:as) is
     54 -> state39 err (i:as) is
     55 -> state39 err (i:as) is
     56 -> state39 err (i:as) is
+    57 -> state39 err (i:as) is
     _ -> err as iis
 
 start39 :: Lexer
@@ -632,12 +637,12 @@ state39 err as iis@(i:is) =
     27 -> state39 err (i:as) is
     28 -> state39 err (i:as) is
     29 -> state39 err (i:as) is
-    51 -> state39 err (i:as) is
     52 -> state39 err (i:as) is
     53 -> state39 err (i:as) is
     54 -> state39 err (i:as) is
     55 -> state39 err (i:as) is
     56 -> state39 err (i:as) is
+    57 -> state39 err (i:as) is
     0 -> err as iis
     1 -> err as iis
     2 -> err as iis
@@ -686,13 +691,13 @@ state44 err as iis@(i:is) =
     9 -> state42 err (i:as) is
     10 -> state42 err (i:as) is
     48 -> state42 err (i:as) is
-    51 -> state42 err (i:as) is
     52 -> state42 err (i:as) is
-    56 -> state42 err (i:as) is
-    63 -> state42 err (i:as) is
-    66 -> state42 err (i:as) is
-    68 -> state42 err (i:as) is
-    70 -> state42 err (i:as) is
+    53 -> state42 err (i:as) is
+    57 -> state42 err (i:as) is
+    64 -> state42 err (i:as) is
+    67 -> state42 err (i:as) is
+    69 -> state42 err (i:as) is
+    71 -> state42 err (i:as) is
     15 -> state45 err (i:as) is
     16 -> state45 err (i:as) is
     17 -> state45 err (i:as) is
@@ -711,9 +716,9 @@ state44 err as iis@(i:is) =
     35 -> state62 err (i:as) is
     37 -> state63 err (i:as) is
     41 -> state64 err (i:as) is
-    49 -> state68 err (i:as) is
-    64 -> state69 err (i:as) is
-    72 -> state71 err (i:as) is
+    50 -> state68 err (i:as) is
+    65 -> state69 err (i:as) is
+    73 -> state71 err (i:as) is
     _ -> err as iis
 
 start45 :: Lexer
@@ -977,6 +982,7 @@ state68 err as iis@(i:is) =
     48 -> state42 err (i:as) is
     49 -> state42 err (i:as) is
     50 -> state42 err (i:as) is
+    51 -> state42 err (i:as) is
     _ -> err as iis
 
 start69 :: Lexer
@@ -1018,12 +1024,12 @@ state71 err as iis@(i:is) =
     27 -> state72 err (i:as) is
     28 -> state72 err (i:as) is
     29 -> state72 err (i:as) is
-    51 -> state72 err (i:as) is
     52 -> state72 err (i:as) is
     53 -> state72 err (i:as) is
     54 -> state72 err (i:as) is
     55 -> state72 err (i:as) is
     56 -> state72 err (i:as) is
+    57 -> state72 err (i:as) is
     _ -> err as iis
 
 start72 :: Lexer
@@ -1042,12 +1048,12 @@ state72 err as iis@(i:is) =
     27 -> state72 err (i:as) is
     28 -> state72 err (i:as) is
     29 -> state72 err (i:as) is
-    51 -> state72 err (i:as) is
     52 -> state72 err (i:as) is
     53 -> state72 err (i:as) is
     54 -> state72 err (i:as) is
     55 -> state72 err (i:as) is
     56 -> state72 err (i:as) is
+    57 -> state72 err (i:as) is
     10 -> state43 err (i:as) is
     _ -> err as iis
 
@@ -1068,8 +1074,9 @@ state74 err as iis@(i:is) =
     21 -> state4 err (i:as) is
     23 -> state4 err (i:as) is
     48 -> state4 err (i:as) is
-    49 -> state4 err (i:as) is
-    75 -> state4 err (i:as) is
+    50 -> state4 err (i:as) is
+    76 -> state4 err (i:as) is
+    77 -> state4 err (i:as) is
     13 -> state75 err (i:as) is
     22 -> state79 err (i:as) is
     _ -> err as iis
@@ -1090,8 +1097,9 @@ state75 err as iis@(i:is) =
     22 -> state4 err (i:as) is
     23 -> state4 err (i:as) is
     48 -> state4 err (i:as) is
-    49 -> state4 err (i:as) is
-    75 -> state4 err (i:as) is
+    50 -> state4 err (i:as) is
+    76 -> state4 err (i:as) is
+    77 -> state4 err (i:as) is
     13 -> state75 err (i:as) is
     _ -> err as iis
   where err _ _ = output Commentstart as (start76 iis)
@@ -1137,8 +1145,9 @@ state79 err as iis@(i:is) =
     22 -> state4 err (i:as) is
     23 -> state4 err (i:as) is
     48 -> state4 err (i:as) is
-    49 -> state4 err (i:as) is
-    75 -> state4 err (i:as) is
+    50 -> state4 err (i:as) is
+    76 -> state4 err (i:as) is
+    77 -> state4 err (i:as) is
     _ -> err as iis
   where err _ _ = output Reservedop as (start1 iis)
 
@@ -1157,8 +1166,9 @@ state80 err as iis@(i:is) =
     22 -> state4 err (i:as) is
     23 -> state4 err (i:as) is
     48 -> state4 err (i:as) is
-    49 -> state4 err (i:as) is
-    75 -> state4 err (i:as) is
+    50 -> state4 err (i:as) is
+    76 -> state4 err (i:as) is
+    77 -> state4 err (i:as) is
     14 -> state79 err (i:as) is
     _ -> err as iis
   where err _ _ = output Varsym as (start1 iis)
@@ -1173,9 +1183,9 @@ state81 err as iis@(i:is) =
     17 -> state87 err (i:as) is
     18 -> state87 err (i:as) is
     38 -> state88 err (i:as) is
-    64 -> state88 err (i:as) is
+    65 -> state88 err (i:as) is
     45 -> state90 err (i:as) is
-    72 -> state90 err (i:as) is
+    73 -> state90 err (i:as) is
     14 -> state82 err (i:as) is
     _ -> err as iis
   where err _ _ = output IntLit as (start1 iis)
@@ -1202,7 +1212,7 @@ state83 err as iis@(i:is) =
     17 -> state83 err (i:as) is
     18 -> state83 err (i:as) is
     28 -> state84 err (i:as) is
-    55 -> state84 err (i:as) is
+    56 -> state84 err (i:as) is
     _ -> err as iis
   where err _ _ = output FloatLit as (start1 iis)
 
@@ -1295,12 +1305,12 @@ state90 err as iis@(i:is) =
     27 -> state91 err (i:as) is
     28 -> state91 err (i:as) is
     29 -> state91 err (i:as) is
-    51 -> state91 err (i:as) is
     52 -> state91 err (i:as) is
     53 -> state91 err (i:as) is
     54 -> state91 err (i:as) is
     55 -> state91 err (i:as) is
     56 -> state91 err (i:as) is
+    57 -> state91 err (i:as) is
     _ -> err as iis
 
 state91 :: LexerState
@@ -1318,12 +1328,12 @@ state91 err as iis@(i:is) =
     27 -> state91 err (i:as) is
     28 -> state91 err (i:as) is
     29 -> state91 err (i:as) is
-    51 -> state91 err (i:as) is
     52 -> state91 err (i:as) is
     53 -> state91 err (i:as) is
     54 -> state91 err (i:as) is
     55 -> state91 err (i:as) is
     56 -> state91 err (i:as) is
+    57 -> state91 err (i:as) is
     _ -> err as iis
   where err _ _ = output IntLit as (start1 iis)
 
@@ -1342,8 +1352,9 @@ state92 err as iis@(i:is) =
     22 -> state93 err (i:as) is
     23 -> state93 err (i:as) is
     48 -> state93 err (i:as) is
-    49 -> state93 err (i:as) is
-    75 -> state93 err (i:as) is
+    50 -> state93 err (i:as) is
+    76 -> state93 err (i:as) is
+    77 -> state93 err (i:as) is
     19 -> state94 err (i:as) is
     _ -> err as iis
   where err _ _ = output Reservedop as (start1 iis)
@@ -1364,8 +1375,9 @@ state93 err as iis@(i:is) =
     22 -> state93 err (i:as) is
     23 -> state93 err (i:as) is
     48 -> state93 err (i:as) is
-    49 -> state93 err (i:as) is
-    75 -> state93 err (i:as) is
+    50 -> state93 err (i:as) is
+    76 -> state93 err (i:as) is
+    77 -> state93 err (i:as) is
     _ -> err as iis
   where err _ _ = output Consym as (start1 iis)
 
@@ -1385,8 +1397,9 @@ state94 err as iis@(i:is) =
     22 -> state93 err (i:as) is
     23 -> state93 err (i:as) is
     48 -> state93 err (i:as) is
-    49 -> state93 err (i:as) is
-    75 -> state93 err (i:as) is
+    50 -> state93 err (i:as) is
+    76 -> state93 err (i:as) is
+    77 -> state93 err (i:as) is
     _ -> err as iis
   where err _ _ = output Reservedop as (start1 iis)
 
@@ -1405,8 +1418,9 @@ state95 err as iis@(i:is) =
     22 -> state4 err (i:as) is
     23 -> state4 err (i:as) is
     48 -> state4 err (i:as) is
-    49 -> state4 err (i:as) is
-    75 -> state4 err (i:as) is
+    50 -> state4 err (i:as) is
+    76 -> state4 err (i:as) is
+    77 -> state4 err (i:as) is
     13 -> state79 err (i:as) is
     _ -> err as iis
   where err _ _ = output Varsym as (start1 iis)
@@ -1426,8 +1440,9 @@ state96 err as iis@(i:is) =
     21 -> state4 err (i:as) is
     23 -> state4 err (i:as) is
     48 -> state4 err (i:as) is
-    49 -> state4 err (i:as) is
-    75 -> state4 err (i:as) is
+    50 -> state4 err (i:as) is
+    76 -> state4 err (i:as) is
+    77 -> state4 err (i:as) is
     22 -> state79 err (i:as) is
     _ -> err as iis
   where err _ _ = output Reservedop as (start1 iis)
@@ -1458,8 +1473,10 @@ state97 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
     14 -> state98 err (i:as) is
     _ -> state97 err (i:as) is
   where err _ _ = output Conid as (start1 iis)
@@ -1485,44 +1502,46 @@ state98 err as iis@(i:is) =
     17 -> err as iis
     18 -> err as iis
     47 -> err as iis
-    74 -> err as iis
-    51 -> state111 err (i:as) is
+    49 -> err as iis
+    75 -> err as iis
     52 -> state111 err (i:as) is
-    56 -> state111 err (i:as) is
+    53 -> state111 err (i:as) is
     57 -> state111 err (i:as) is
     58 -> state111 err (i:as) is
-    60 -> state111 err (i:as) is
-    65 -> state111 err (i:as) is
+    59 -> state111 err (i:as) is
+    61 -> state111 err (i:as) is
     66 -> state111 err (i:as) is
     67 -> state111 err (i:as) is
-    69 -> state111 err (i:as) is
+    68 -> state111 err (i:as) is
     70 -> state111 err (i:as) is
-    72 -> state111 err (i:as) is
+    71 -> state111 err (i:as) is
     73 -> state111 err (i:as) is
+    74 -> state111 err (i:as) is
     7 -> state99 err (i:as) is
     9 -> state99 err (i:as) is
     12 -> state99 err (i:as) is
     22 -> state99 err (i:as) is
-    49 -> state99 err (i:as) is
+    50 -> state99 err (i:as) is
     23 -> state102 err (i:as) is
     48 -> state102 err (i:as) is
-    75 -> state102 err (i:as) is
+    76 -> state102 err (i:as) is
+    77 -> state102 err (i:as) is
     13 -> state100 err (i:as) is
     14 -> state103 err (i:as) is
     19 -> state104 err (i:as) is
     20 -> state107 err (i:as) is
     21 -> state108 err (i:as) is
-    50 -> state110 err (i:as) is
-    53 -> state112 err (i:as) is
-    54 -> state118 err (i:as) is
-    55 -> state131 err (i:as) is
-    59 -> state132 err (i:as) is
-    61 -> state144 err (i:as) is
-    62 -> state145 err (i:as) is
-    63 -> state149 err (i:as) is
-    64 -> state154 err (i:as) is
-    68 -> state155 err (i:as) is
-    71 -> state158 err (i:as) is
+    51 -> state110 err (i:as) is
+    54 -> state112 err (i:as) is
+    55 -> state118 err (i:as) is
+    56 -> state131 err (i:as) is
+    60 -> state132 err (i:as) is
+    62 -> state144 err (i:as) is
+    63 -> state145 err (i:as) is
+    64 -> state149 err (i:as) is
+    65 -> state154 err (i:as) is
+    69 -> state155 err (i:as) is
+    72 -> state158 err (i:as) is
     _ -> state109 err (i:as) is
 
 state99 :: LexerState
@@ -1541,8 +1560,9 @@ state99 err as iis@(i:is) =
     22 -> state99 err (i:as) is
     23 -> state99 err (i:as) is
     48 -> state99 err (i:as) is
-    49 -> state99 err (i:as) is
-    75 -> state99 err (i:as) is
+    50 -> state99 err (i:as) is
+    76 -> state99 err (i:as) is
+    77 -> state99 err (i:as) is
     _ -> err as iis
   where err _ _ = output Qvarsym as (start1 iis)
 
@@ -1560,8 +1580,9 @@ state100 err as iis@(i:is) =
     21 -> state99 err (i:as) is
     23 -> state99 err (i:as) is
     48 -> state99 err (i:as) is
-    49 -> state99 err (i:as) is
-    75 -> state99 err (i:as) is
+    50 -> state99 err (i:as) is
+    76 -> state99 err (i:as) is
+    77 -> state99 err (i:as) is
     13 -> state101 err (i:as) is
     22 -> state102 err (i:as) is
     _ -> err as iis
@@ -1583,8 +1604,9 @@ state101 err as iis@(i:is) =
     22 -> state99 err (i:as) is
     23 -> state99 err (i:as) is
     48 -> state99 err (i:as) is
-    49 -> state99 err (i:as) is
-    75 -> state99 err (i:as) is
+    50 -> state99 err (i:as) is
+    76 -> state99 err (i:as) is
+    77 -> state99 err (i:as) is
     13 -> state101 err (i:as) is
     _ -> err as iis
 
@@ -1605,8 +1627,9 @@ state102 err as iis@(i:is) =
     22 -> state99 err (i:as) is
     23 -> state99 err (i:as) is
     48 -> state99 err (i:as) is
-    49 -> state99 err (i:as) is
-    75 -> state99 err (i:as) is
+    50 -> state99 err (i:as) is
+    76 -> state99 err (i:as) is
+    77 -> state99 err (i:as) is
     _ -> err as iis
 
 state103 :: LexerState
@@ -1624,8 +1647,9 @@ state103 err as iis@(i:is) =
     22 -> state99 err (i:as) is
     23 -> state99 err (i:as) is
     48 -> state99 err (i:as) is
-    49 -> state99 err (i:as) is
-    75 -> state99 err (i:as) is
+    50 -> state99 err (i:as) is
+    76 -> state99 err (i:as) is
+    77 -> state99 err (i:as) is
     14 -> state102 err (i:as) is
     _ -> err as iis
   where err _ _ = output Qvarsym as (start1 iis)
@@ -1646,8 +1670,9 @@ state104 err as iis@(i:is) =
     22 -> state105 err (i:as) is
     23 -> state105 err (i:as) is
     48 -> state105 err (i:as) is
-    49 -> state105 err (i:as) is
-    75 -> state105 err (i:as) is
+    50 -> state105 err (i:as) is
+    76 -> state105 err (i:as) is
+    77 -> state105 err (i:as) is
     19 -> state106 err (i:as) is
     _ -> err as iis
 
@@ -1667,8 +1692,9 @@ state105 err as iis@(i:is) =
     22 -> state105 err (i:as) is
     23 -> state105 err (i:as) is
     48 -> state105 err (i:as) is
-    49 -> state105 err (i:as) is
-    75 -> state105 err (i:as) is
+    50 -> state105 err (i:as) is
+    76 -> state105 err (i:as) is
+    77 -> state105 err (i:as) is
     _ -> err as iis
   where err _ _ = output Qconsym as (start1 iis)
 
@@ -1689,8 +1715,9 @@ state106 err as iis@(i:is) =
     22 -> state105 err (i:as) is
     23 -> state105 err (i:as) is
     48 -> state105 err (i:as) is
-    49 -> state105 err (i:as) is
-    75 -> state105 err (i:as) is
+    50 -> state105 err (i:as) is
+    76 -> state105 err (i:as) is
+    77 -> state105 err (i:as) is
     _ -> err as iis
 
 state107 :: LexerState
@@ -1708,8 +1735,9 @@ state107 err as iis@(i:is) =
     22 -> state99 err (i:as) is
     23 -> state99 err (i:as) is
     48 -> state99 err (i:as) is
-    49 -> state99 err (i:as) is
-    75 -> state99 err (i:as) is
+    50 -> state99 err (i:as) is
+    76 -> state99 err (i:as) is
+    77 -> state99 err (i:as) is
     13 -> state102 err (i:as) is
     _ -> err as iis
   where err _ _ = output Qvarsym as (start1 iis)
@@ -1730,8 +1758,9 @@ state108 err as iis@(i:is) =
     21 -> state99 err (i:as) is
     23 -> state99 err (i:as) is
     48 -> state99 err (i:as) is
-    49 -> state99 err (i:as) is
-    75 -> state99 err (i:as) is
+    50 -> state99 err (i:as) is
+    76 -> state99 err (i:as) is
+    77 -> state99 err (i:as) is
     22 -> state102 err (i:as) is
     _ -> err as iis
 
@@ -1761,8 +1790,10 @@ state109 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
     14 -> state98 err (i:as) is
     _ -> state109 err (i:as) is
   where err _ _ = output Qconid as (start1 iis)
@@ -1795,8 +1826,10 @@ state110 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
     _ -> state111 err (i:as) is
 
 state111 :: LexerState
@@ -1826,8 +1859,10 @@ state111 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -1858,10 +1893,12 @@ state112 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    51 -> state113 err (i:as) is
-    61 -> state115 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    52 -> state113 err (i:as) is
+    62 -> state115 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -1892,9 +1929,11 @@ state113 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    67 -> state114 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    68 -> state114 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -1925,9 +1964,11 @@ state114 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    55 -> state110 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    56 -> state110 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -1958,9 +1999,11 @@ state115 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    51 -> state116 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    52 -> state116 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -1991,9 +2034,11 @@ state116 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    67 -> state117 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    68 -> state117 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2024,9 +2069,11 @@ state117 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    67 -> state110 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    68 -> state110 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2057,11 +2104,13 @@ state118 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    64 -> state110 err (i:as) is
-    51 -> state119 err (i:as) is
-    55 -> state121 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    65 -> state110 err (i:as) is
+    52 -> state119 err (i:as) is
+    56 -> state121 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2092,9 +2141,11 @@ state119 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    68 -> state120 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    69 -> state120 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2125,9 +2176,11 @@ state120 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    51 -> state110 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    52 -> state110 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2158,10 +2211,12 @@ state121 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    56 -> state122 err (i:as) is
-    66 -> state126 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    57 -> state122 err (i:as) is
+    67 -> state126 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2192,9 +2247,11 @@ state122 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    51 -> state123 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    52 -> state123 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2225,9 +2282,11 @@ state123 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    69 -> state124 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    70 -> state124 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2258,9 +2317,11 @@ state124 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    61 -> state125 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    62 -> state125 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2291,9 +2352,11 @@ state125 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    68 -> state110 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    69 -> state110 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2324,9 +2387,11 @@ state126 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    59 -> state127 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    60 -> state127 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2357,9 +2422,11 @@ state127 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    70 -> state128 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    71 -> state128 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2390,9 +2457,11 @@ state128 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    59 -> state129 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    60 -> state129 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2423,9 +2492,11 @@ state129 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    63 -> state130 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    64 -> state130 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2456,9 +2527,11 @@ state130 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    57 -> state110 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    58 -> state110 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2489,9 +2562,11 @@ state131 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    61 -> state113 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    62 -> state113 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2522,11 +2597,13 @@ state132 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    56 -> state110 err (i:as) is
-    62 -> state133 err (i:as) is
-    63 -> state136 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    57 -> state110 err (i:as) is
+    63 -> state133 err (i:as) is
+    64 -> state136 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2557,9 +2634,11 @@ state133 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    65 -> state134 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    66 -> state134 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2590,9 +2669,11 @@ state134 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    64 -> state135 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    65 -> state135 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2623,9 +2704,11 @@ state135 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    66 -> state125 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    67 -> state125 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2657,10 +2740,12 @@ state136 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    56 -> state137 err (i:as) is
-    67 -> state140 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    57 -> state137 err (i:as) is
+    68 -> state140 err (i:as) is
     _ -> state111 err (i:as) is
 
 state137 :: LexerState
@@ -2690,9 +2775,11 @@ state137 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    59 -> state138 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    60 -> state138 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2723,9 +2810,11 @@ state138 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    72 -> state139 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    73 -> state139 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2757,10 +2846,12 @@ state139 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    61 -> state110 err (i:as) is
-    66 -> state110 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    62 -> state110 err (i:as) is
+    67 -> state110 err (i:as) is
     _ -> state111 err (i:as) is
 
 state140 :: LexerState
@@ -2790,9 +2881,11 @@ state140 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    68 -> state141 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    69 -> state141 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2823,9 +2916,11 @@ state141 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    51 -> state142 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    52 -> state142 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2856,9 +2951,11 @@ state142 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    63 -> state143 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    64 -> state143 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2889,9 +2986,11 @@ state143 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    53 -> state114 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    54 -> state114 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2922,9 +3021,11 @@ state144 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    55 -> state125 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    56 -> state125 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2955,9 +3056,11 @@ state145 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    64 -> state146 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    65 -> state146 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -2988,9 +3091,11 @@ state146 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    54 -> state147 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    55 -> state147 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -3021,9 +3126,11 @@ state147 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    69 -> state148 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    70 -> state148 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -3054,9 +3161,11 @@ state148 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    61 -> state114 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    62 -> state114 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -3087,9 +3196,11 @@ state149 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    55 -> state150 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    56 -> state150 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -3120,9 +3231,11 @@ state150 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    71 -> state151 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    72 -> state151 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -3153,9 +3266,11 @@ state151 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    68 -> state152 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    69 -> state152 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -3186,9 +3301,11 @@ state152 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    73 -> state153 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    74 -> state153 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -3219,9 +3336,11 @@ state153 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    65 -> state114 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    66 -> state114 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -3252,9 +3371,11 @@ state154 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    56 -> state110 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    57 -> state110 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -3285,10 +3406,12 @@ state155 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    73 -> state153 err (i:as) is
-    58 -> state156 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    74 -> state153 err (i:as) is
+    59 -> state156 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -3319,9 +3442,11 @@ state156 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    55 -> state157 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    56 -> state157 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -3352,9 +3477,11 @@ state157 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    63 -> state110 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    64 -> state110 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -3385,9 +3512,11 @@ state158 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    58 -> state159 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    59 -> state159 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -3418,9 +3547,11 @@ state159 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    55 -> state160 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    56 -> state160 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
@@ -3451,47 +3582,74 @@ state160 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    66 -> state114 err (i:as) is
+    76 -> err as iis
+    77 -> err as iis
+    67 -> state114 err (i:as) is
     _ -> state111 err (i:as) is
   where err _ _ = output Qvarid as (start1 iis)
 
 state161 :: LexerState
 state161 err as [] = err as []
-  where err _ _ = output Reservedid as (start1 [])
+  where err _ _ = output Special as (start1 [])
 state161 err as iis@(i:is) =
   case cclass i of
-    0 -> err as iis
-    1 -> err as iis
-    2 -> err as iis
-    3 -> err as iis
-    4 -> err as iis
-    5 -> err as iis
-    6 -> err as iis
-    7 -> err as iis
-    8 -> err as iis
-    9 -> err as iis
-    11 -> err as iis
-    12 -> err as iis
-    13 -> err as iis
-    14 -> err as iis
-    19 -> err as iis
-    20 -> err as iis
-    21 -> err as iis
-    22 -> err as iis
-    23 -> err as iis
-    47 -> err as iis
-    48 -> err as iis
-    49 -> err as iis
-    74 -> err as iis
-    75 -> err as iis
-    _ -> state162 err (i:as) is
-  where err _ _ = output Reservedid as (start1 iis)
+    24 -> state162 err (i:as) is
+    25 -> state162 err (i:as) is
+    26 -> state162 err (i:as) is
+    27 -> state162 err (i:as) is
+    28 -> state162 err (i:as) is
+    29 -> state162 err (i:as) is
+    30 -> state162 err (i:as) is
+    31 -> state162 err (i:as) is
+    32 -> state162 err (i:as) is
+    33 -> state162 err (i:as) is
+    34 -> state162 err (i:as) is
+    35 -> state162 err (i:as) is
+    36 -> state162 err (i:as) is
+    37 -> state162 err (i:as) is
+    38 -> state162 err (i:as) is
+    39 -> state162 err (i:as) is
+    40 -> state162 err (i:as) is
+    41 -> state162 err (i:as) is
+    42 -> state162 err (i:as) is
+    43 -> state162 err (i:as) is
+    44 -> state162 err (i:as) is
+    45 -> state162 err (i:as) is
+    46 -> state162 err (i:as) is
+    78 -> state162 err (i:as) is
+    52 -> state219 err (i:as) is
+    53 -> state219 err (i:as) is
+    57 -> state219 err (i:as) is
+    58 -> state219 err (i:as) is
+    59 -> state219 err (i:as) is
+    61 -> state219 err (i:as) is
+    66 -> state219 err (i:as) is
+    67 -> state219 err (i:as) is
+    68 -> state219 err (i:as) is
+    70 -> state219 err (i:as) is
+    71 -> state219 err (i:as) is
+    73 -> state219 err (i:as) is
+    74 -> state219 err (i:as) is
+    51 -> state218 err (i:as) is
+    54 -> state223 err (i:as) is
+    55 -> state229 err (i:as) is
+    56 -> state242 err (i:as) is
+    60 -> state243 err (i:as) is
+    62 -> state255 err (i:as) is
+    63 -> state256 err (i:as) is
+    64 -> state260 err (i:as) is
+    65 -> state265 err (i:as) is
+    69 -> state266 err (i:as) is
+    72 -> state269 err (i:as) is
+    _ -> err as iis
+  where err _ _ = output Special as (start1 iis)
 
+start162 :: Lexer
+start162 is = state162 (\ as is -> gotError as is) "" is
 state162 :: LexerState
 state162 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state162 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -3507,7 +3665,6 @@ state162 err as iis@(i:is) =
     11 -> err as iis
     12 -> err as iis
     13 -> err as iis
-    14 -> err as iis
     19 -> err as iis
     20 -> err as iis
     21 -> err as iis
@@ -3516,48 +3673,73 @@ state162 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    14 -> state163 err (i:as) is
     _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
 
+start163 :: Lexer
+start163 is = state163 (\ as is -> gotError as is) "" is
 state163 :: LexerState
 state163 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state163 err as iis@(i:is) =
   case cclass i of
-    0 -> err as iis
-    1 -> err as iis
-    2 -> err as iis
-    3 -> err as iis
-    4 -> err as iis
-    5 -> err as iis
-    6 -> err as iis
-    7 -> err as iis
-    8 -> err as iis
-    9 -> err as iis
-    11 -> err as iis
-    12 -> err as iis
-    13 -> err as iis
-    14 -> err as iis
-    19 -> err as iis
-    20 -> err as iis
-    21 -> err as iis
-    22 -> err as iis
-    23 -> err as iis
-    47 -> err as iis
-    48 -> err as iis
-    49 -> err as iis
-    74 -> err as iis
-    75 -> err as iis
+    24 -> state162 err (i:as) is
+    25 -> state162 err (i:as) is
+    26 -> state162 err (i:as) is
+    27 -> state162 err (i:as) is
+    28 -> state162 err (i:as) is
+    29 -> state162 err (i:as) is
+    30 -> state162 err (i:as) is
+    31 -> state162 err (i:as) is
+    32 -> state162 err (i:as) is
+    33 -> state162 err (i:as) is
+    34 -> state162 err (i:as) is
+    35 -> state162 err (i:as) is
+    36 -> state162 err (i:as) is
+    37 -> state162 err (i:as) is
+    38 -> state162 err (i:as) is
+    39 -> state162 err (i:as) is
+    40 -> state162 err (i:as) is
+    41 -> state162 err (i:as) is
+    42 -> state162 err (i:as) is
+    43 -> state162 err (i:as) is
+    44 -> state162 err (i:as) is
+    45 -> state162 err (i:as) is
+    46 -> state162 err (i:as) is
+    78 -> state162 err (i:as) is
+    52 -> state165 err (i:as) is
+    53 -> state165 err (i:as) is
+    57 -> state165 err (i:as) is
+    58 -> state165 err (i:as) is
+    59 -> state165 err (i:as) is
+    61 -> state165 err (i:as) is
+    66 -> state165 err (i:as) is
+    67 -> state165 err (i:as) is
+    68 -> state165 err (i:as) is
+    70 -> state165 err (i:as) is
+    71 -> state165 err (i:as) is
+    73 -> state165 err (i:as) is
+    74 -> state165 err (i:as) is
     51 -> state164 err (i:as) is
-    61 -> state166 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    54 -> state169 err (i:as) is
+    55 -> state175 err (i:as) is
+    56 -> state188 err (i:as) is
+    60 -> state189 err (i:as) is
+    62 -> state201 err (i:as) is
+    63 -> state202 err (i:as) is
+    64 -> state206 err (i:as) is
+    65 -> state211 err (i:as) is
+    69 -> state212 err (i:as) is
+    72 -> state215 err (i:as) is
+    _ -> err as iis
 
+start164 :: Lexer
+start164 is = state164 (\ as is -> gotError as is) "" is
 state164 :: LexerState
 state164 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state164 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -3582,15 +3764,16 @@ state164 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    67 -> state165 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    76 -> err as iis
+    77 -> err as iis
+    _ -> state165 err (i:as) is
 
+start165 :: Lexer
+start165 is = state165 (\ as is -> gotError as is) "" is
 state165 :: LexerState
 state165 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state165 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -3615,114 +3798,38 @@ state165 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    55 -> state161 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start166 :: Lexer
+start166 is = state166 (\ as is -> gotError as is) "" is
 state166 :: LexerState
 state166 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state166 err as iis@(i:is) =
   case cclass i of
+    49 -> state168 err (i:as) is
+    76 -> state168 err (i:as) is
     0 -> err as iis
-    1 -> err as iis
-    2 -> err as iis
-    3 -> err as iis
-    4 -> err as iis
-    5 -> err as iis
-    6 -> err as iis
-    7 -> err as iis
-    8 -> err as iis
-    9 -> err as iis
-    11 -> err as iis
-    12 -> err as iis
-    13 -> err as iis
-    14 -> err as iis
-    19 -> err as iis
-    20 -> err as iis
-    21 -> err as iis
-    22 -> err as iis
-    23 -> err as iis
-    47 -> err as iis
-    48 -> err as iis
-    49 -> err as iis
-    74 -> err as iis
-    75 -> err as iis
-    51 -> state167 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
-
-state167 :: LexerState
-state167 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
-state167 err as iis@(i:is) =
-  case cclass i of
-    0 -> err as iis
-    1 -> err as iis
-    2 -> err as iis
-    3 -> err as iis
-    4 -> err as iis
-    5 -> err as iis
-    6 -> err as iis
-    7 -> err as iis
-    8 -> err as iis
-    9 -> err as iis
-    11 -> err as iis
-    12 -> err as iis
-    13 -> err as iis
-    14 -> err as iis
-    19 -> err as iis
-    20 -> err as iis
-    21 -> err as iis
-    22 -> err as iis
-    23 -> err as iis
-    47 -> err as iis
-    48 -> err as iis
-    49 -> err as iis
-    74 -> err as iis
-    75 -> err as iis
-    67 -> state168 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    _ -> state166 err (i:as) is
 
 state168 :: LexerState
 state168 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
+  where err _ _ = output Qquasiquote as (start1 [])
 state168 err as iis@(i:is) =
   case cclass i of
+    49 -> state168 err (i:as) is
+    76 -> state168 err (i:as) is
     0 -> err as iis
-    1 -> err as iis
-    2 -> err as iis
-    3 -> err as iis
-    4 -> err as iis
-    5 -> err as iis
-    6 -> err as iis
-    7 -> err as iis
-    8 -> err as iis
-    9 -> err as iis
-    11 -> err as iis
-    12 -> err as iis
-    13 -> err as iis
-    14 -> err as iis
-    19 -> err as iis
-    20 -> err as iis
-    21 -> err as iis
-    22 -> err as iis
-    23 -> err as iis
-    47 -> err as iis
-    48 -> err as iis
-    49 -> err as iis
-    74 -> err as iis
-    75 -> err as iis
-    67 -> state161 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    _ -> state166 err (i:as) is
+  where err _ _ = output Qquasiquote as (start1 iis)
 
+start169 :: Lexer
+start169 is = state169 (\ as is -> gotError as is) "" is
 state169 :: LexerState
 state169 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state169 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -3747,17 +3854,18 @@ state169 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    64 -> state161 err (i:as) is
-    51 -> state170 err (i:as) is
-    55 -> state172 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    52 -> state170 err (i:as) is
+    62 -> state172 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start170 :: Lexer
+start170 is = state170 (\ as is -> gotError as is) "" is
 state170 :: LexerState
 state170 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state170 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -3782,15 +3890,17 @@ state170 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
+    77 -> err as iis
+    76 -> state166 err (i:as) is
     68 -> state171 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    _ -> state165 err (i:as) is
 
+start171 :: Lexer
+start171 is = state171 (\ as is -> gotError as is) "" is
 state171 :: LexerState
 state171 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state171 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -3815,15 +3925,17 @@ state171 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    51 -> state161 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    56 -> state164 err (i:as) is
+    76 -> state166 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start172 :: Lexer
+start172 is = state172 (\ as is -> gotError as is) "" is
 state172 :: LexerState
 state172 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state172 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -3848,16 +3960,17 @@ state172 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    56 -> state173 err (i:as) is
-    66 -> state177 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    52 -> state173 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start173 :: Lexer
+start173 is = state173 (\ as is -> gotError as is) "" is
 state173 :: LexerState
 state173 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state173 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -3882,15 +3995,17 @@ state173 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    51 -> state174 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    68 -> state174 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start174 :: Lexer
+start174 is = state174 (\ as is -> gotError as is) "" is
 state174 :: LexerState
 state174 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state174 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -3915,15 +4030,17 @@ state174 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    69 -> state175 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    68 -> state164 err (i:as) is
+    76 -> state166 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start175 :: Lexer
+start175 is = state175 (\ as is -> gotError as is) "" is
 state175 :: LexerState
 state175 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state175 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -3948,15 +4065,19 @@ state175 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    61 -> state176 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    65 -> state164 err (i:as) is
+    76 -> state166 err (i:as) is
+    52 -> state176 err (i:as) is
+    56 -> state178 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start176 :: Lexer
+start176 is = state176 (\ as is -> gotError as is) "" is
 state176 :: LexerState
 state176 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state176 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -3981,15 +4102,17 @@ state176 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    68 -> state161 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    69 -> state177 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start177 :: Lexer
+start177 is = state177 (\ as is -> gotError as is) "" is
 state177 :: LexerState
 state177 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state177 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4014,15 +4137,17 @@ state177 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    59 -> state178 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    52 -> state164 err (i:as) is
+    76 -> state166 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start178 :: Lexer
+start178 is = state178 (\ as is -> gotError as is) "" is
 state178 :: LexerState
 state178 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state178 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4047,15 +4172,18 @@ state178 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    70 -> state179 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    57 -> state179 err (i:as) is
+    67 -> state183 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start179 :: Lexer
+start179 is = state179 (\ as is -> gotError as is) "" is
 state179 :: LexerState
 state179 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state179 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4080,15 +4208,17 @@ state179 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    59 -> state180 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    52 -> state180 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start180 :: Lexer
+start180 is = state180 (\ as is -> gotError as is) "" is
 state180 :: LexerState
 state180 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state180 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4113,15 +4243,17 @@ state180 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    63 -> state181 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    70 -> state181 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start181 :: Lexer
+start181 is = state181 (\ as is -> gotError as is) "" is
 state181 :: LexerState
 state181 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state181 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4146,15 +4278,17 @@ state181 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    57 -> state161 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    62 -> state182 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start182 :: Lexer
+start182 is = state182 (\ as is -> gotError as is) "" is
 state182 :: LexerState
 state182 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state182 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4179,15 +4313,17 @@ state182 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    61 -> state164 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    69 -> state164 err (i:as) is
+    76 -> state166 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start183 :: Lexer
+start183 is = state183 (\ as is -> gotError as is) "" is
 state183 :: LexerState
 state183 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state183 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4212,17 +4348,17 @@ state183 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    56 -> state161 err (i:as) is
-    62 -> state184 err (i:as) is
-    63 -> state187 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    60 -> state184 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start184 :: Lexer
+start184 is = state184 (\ as is -> gotError as is) "" is
 state184 :: LexerState
 state184 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state184 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4247,15 +4383,17 @@ state184 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    65 -> state185 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    71 -> state185 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start185 :: Lexer
+start185 is = state185 (\ as is -> gotError as is) "" is
 state185 :: LexerState
 state185 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state185 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4280,15 +4418,17 @@ state185 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    64 -> state186 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    60 -> state186 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start186 :: Lexer
+start186 is = state186 (\ as is -> gotError as is) "" is
 state186 :: LexerState
 state186 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state186 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4313,15 +4453,17 @@ state186 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    66 -> state176 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    64 -> state187 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start187 :: Lexer
+start187 is = state187 (\ as is -> gotError as is) "" is
 state187 :: LexerState
 state187 err as [] = err as []
-  where err _ _ = output Reservedid as (start1 [])
 state187 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4346,16 +4488,17 @@ state187 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    56 -> state188 err (i:as) is
-    67 -> state191 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Reservedid as (start1 iis)
+    77 -> err as iis
+    58 -> state164 err (i:as) is
+    76 -> state166 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start188 :: Lexer
+start188 is = state188 (\ as is -> gotError as is) "" is
 state188 :: LexerState
 state188 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state188 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4380,15 +4523,17 @@ state188 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    59 -> state189 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    62 -> state170 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start189 :: Lexer
+start189 is = state189 (\ as is -> gotError as is) "" is
 state189 :: LexerState
 state189 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state189 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4413,15 +4558,19 @@ state189 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    72 -> state190 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    57 -> state164 err (i:as) is
+    76 -> state166 err (i:as) is
+    63 -> state190 err (i:as) is
+    64 -> state193 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start190 :: Lexer
+start190 is = state190 (\ as is -> gotError as is) "" is
 state190 :: LexerState
 state190 err as [] = err as []
-  where err _ _ = output Reservedid as (start1 [])
 state190 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4446,16 +4595,17 @@ state190 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    61 -> state161 err (i:as) is
-    66 -> state161 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Reservedid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    66 -> state191 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start191 :: Lexer
+start191 is = state191 (\ as is -> gotError as is) "" is
 state191 :: LexerState
 state191 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state191 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4480,15 +4630,17 @@ state191 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    68 -> state192 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    65 -> state192 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start192 :: Lexer
+start192 is = state192 (\ as is -> gotError as is) "" is
 state192 :: LexerState
 state192 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state192 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4513,15 +4665,17 @@ state192 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    51 -> state193 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    67 -> state182 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start193 :: Lexer
+start193 is = state193 (\ as is -> gotError as is) "" is
 state193 :: LexerState
 state193 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state193 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4546,15 +4700,18 @@ state193 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    63 -> state194 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    76 -> err as iis
+    77 -> err as iis
+    57 -> state194 err (i:as) is
+    68 -> state197 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start194 :: Lexer
+start194 is = state194 (\ as is -> gotError as is) "" is
 state194 :: LexerState
 state194 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state194 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4579,15 +4736,17 @@ state194 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    53 -> state165 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    60 -> state195 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start195 :: Lexer
+start195 is = state195 (\ as is -> gotError as is) "" is
 state195 :: LexerState
 state195 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state195 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4612,15 +4771,17 @@ state195 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    55 -> state176 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    73 -> state196 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start196 :: Lexer
+start196 is = state196 (\ as is -> gotError as is) "" is
 state196 :: LexerState
 state196 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state196 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4645,15 +4806,18 @@ state196 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    64 -> state197 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    76 -> err as iis
+    77 -> err as iis
+    62 -> state164 err (i:as) is
+    67 -> state164 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start197 :: Lexer
+start197 is = state197 (\ as is -> gotError as is) "" is
 state197 :: LexerState
 state197 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state197 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4678,15 +4842,17 @@ state197 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    54 -> state198 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    69 -> state198 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start198 :: Lexer
+start198 is = state198 (\ as is -> gotError as is) "" is
 state198 :: LexerState
 state198 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state198 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4711,15 +4877,17 @@ state198 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    69 -> state199 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    52 -> state199 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start199 :: Lexer
+start199 is = state199 (\ as is -> gotError as is) "" is
 state199 :: LexerState
 state199 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state199 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4744,15 +4912,17 @@ state199 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    61 -> state165 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    64 -> state200 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start200 :: Lexer
+start200 is = state200 (\ as is -> gotError as is) "" is
 state200 :: LexerState
 state200 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state200 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4777,15 +4947,17 @@ state200 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    55 -> state201 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    54 -> state171 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start201 :: Lexer
+start201 is = state201 (\ as is -> gotError as is) "" is
 state201 :: LexerState
 state201 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state201 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4810,15 +4982,17 @@ state201 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    71 -> state202 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    56 -> state182 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start202 :: Lexer
+start202 is = state202 (\ as is -> gotError as is) "" is
 state202 :: LexerState
 state202 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state202 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4843,15 +5017,17 @@ state202 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    68 -> state203 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    65 -> state203 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start203 :: Lexer
+start203 is = state203 (\ as is -> gotError as is) "" is
 state203 :: LexerState
 state203 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state203 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4876,15 +5052,17 @@ state203 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    73 -> state204 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    55 -> state204 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start204 :: Lexer
+start204 is = state204 (\ as is -> gotError as is) "" is
 state204 :: LexerState
 state204 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state204 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4909,15 +5087,17 @@ state204 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    65 -> state165 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    70 -> state205 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start205 :: Lexer
+start205 is = state205 (\ as is -> gotError as is) "" is
 state205 :: LexerState
 state205 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state205 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4942,15 +5122,17 @@ state205 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    56 -> state161 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    62 -> state171 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start206 :: Lexer
+start206 is = state206 (\ as is -> gotError as is) "" is
 state206 :: LexerState
 state206 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state206 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -4975,16 +5157,17 @@ state206 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    73 -> state204 err (i:as) is
-    58 -> state207 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    56 -> state207 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start207 :: Lexer
+start207 is = state207 (\ as is -> gotError as is) "" is
 state207 :: LexerState
 state207 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state207 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -5009,15 +5192,17 @@ state207 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    55 -> state208 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    72 -> state208 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start208 :: Lexer
+start208 is = state208 (\ as is -> gotError as is) "" is
 state208 :: LexerState
 state208 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state208 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -5042,15 +5227,17 @@ state208 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    63 -> state161 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    69 -> state209 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start209 :: Lexer
+start209 is = state209 (\ as is -> gotError as is) "" is
 state209 :: LexerState
 state209 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state209 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -5075,15 +5262,17 @@ state209 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    58 -> state210 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    74 -> state210 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start210 :: Lexer
+start210 is = state210 (\ as is -> gotError as is) "" is
 state210 :: LexerState
 state210 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state210 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -5108,15 +5297,17 @@ state210 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    55 -> state211 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    66 -> state171 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start211 :: Lexer
+start211 is = state211 (\ as is -> gotError as is) "" is
 state211 :: LexerState
 state211 err as [] = err as []
-  where err _ _ = output Varid as (start1 [])
 state211 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
@@ -5141,25 +5332,3843 @@ state211 err as iis@(i:is) =
     47 -> err as iis
     48 -> err as iis
     49 -> err as iis
-    74 -> err as iis
+    50 -> err as iis
     75 -> err as iis
-    66 -> state165 err (i:as) is
-    _ -> state162 err (i:as) is
-  where err _ _ = output Varid as (start1 iis)
+    77 -> err as iis
+    57 -> state164 err (i:as) is
+    76 -> state166 err (i:as) is
+    _ -> state165 err (i:as) is
 
+start212 :: Lexer
+start212 is = state212 (\ as is -> gotError as is) "" is
 state212 :: LexerState
 state212 err as [] = err as []
-  where err _ _ = output Special as (start1 [])
 state212 err as iis@(i:is) =
   case cclass i of
-    13 -> state213 err (i:as) is
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    74 -> state210 err (i:as) is
+    59 -> state213 err (i:as) is
+    _ -> state165 err (i:as) is
+
+start213 :: Lexer
+start213 is = state213 (\ as is -> gotError as is) "" is
+state213 :: LexerState
+state213 err as [] = err as []
+state213 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    56 -> state214 err (i:as) is
+    _ -> state165 err (i:as) is
+
+start214 :: Lexer
+start214 is = state214 (\ as is -> gotError as is) "" is
+state214 :: LexerState
+state214 err as [] = err as []
+state214 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    64 -> state164 err (i:as) is
+    76 -> state166 err (i:as) is
+    _ -> state165 err (i:as) is
+
+start215 :: Lexer
+start215 is = state215 (\ as is -> gotError as is) "" is
+state215 :: LexerState
+state215 err as [] = err as []
+state215 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    59 -> state216 err (i:as) is
+    _ -> state165 err (i:as) is
+
+start216 :: Lexer
+start216 is = state216 (\ as is -> gotError as is) "" is
+state216 :: LexerState
+state216 err as [] = err as []
+state216 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    56 -> state217 err (i:as) is
+    _ -> state165 err (i:as) is
+
+start217 :: Lexer
+start217 is = state217 (\ as is -> gotError as is) "" is
+state217 :: LexerState
+state217 err as [] = err as []
+state217 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state166 err (i:as) is
+    67 -> state171 err (i:as) is
+    _ -> state165 err (i:as) is
+
+start218 :: Lexer
+start218 is = state218 (\ as is -> gotError as is) "" is
+state218 :: LexerState
+state218 err as [] = err as []
+state218 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    _ -> state219 err (i:as) is
+
+start219 :: Lexer
+start219 is = state219 (\ as is -> gotError as is) "" is
+state219 :: LexerState
+state219 err as [] = err as []
+state219 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start220 :: Lexer
+start220 is = state220 (\ as is -> gotError as is) "" is
+state220 :: LexerState
+state220 err as [] = err as []
+state220 err as iis@(i:is) =
+  case cclass i of
+    49 -> state222 err (i:as) is
+    76 -> state222 err (i:as) is
+    0 -> err as iis
+    _ -> state220 err (i:as) is
+
+state222 :: LexerState
+state222 err as [] = err as []
+  where err _ _ = output Quasiquote as (start1 [])
+state222 err as iis@(i:is) =
+  case cclass i of
+    49 -> state222 err (i:as) is
+    76 -> state222 err (i:as) is
+    0 -> err as iis
+    _ -> state220 err (i:as) is
+  where err _ _ = output Quasiquote as (start1 iis)
+
+start223 :: Lexer
+start223 is = state223 (\ as is -> gotError as is) "" is
+state223 :: LexerState
+state223 err as [] = err as []
+state223 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    52 -> state224 err (i:as) is
+    62 -> state226 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start224 :: Lexer
+start224 is = state224 (\ as is -> gotError as is) "" is
+state224 :: LexerState
+state224 err as [] = err as []
+state224 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    68 -> state225 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start225 :: Lexer
+start225 is = state225 (\ as is -> gotError as is) "" is
+state225 :: LexerState
+state225 err as [] = err as []
+state225 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    56 -> state218 err (i:as) is
+    76 -> state220 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start226 :: Lexer
+start226 is = state226 (\ as is -> gotError as is) "" is
+state226 :: LexerState
+state226 err as [] = err as []
+state226 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    52 -> state227 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start227 :: Lexer
+start227 is = state227 (\ as is -> gotError as is) "" is
+state227 :: LexerState
+state227 err as [] = err as []
+state227 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    68 -> state228 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start228 :: Lexer
+start228 is = state228 (\ as is -> gotError as is) "" is
+state228 :: LexerState
+state228 err as [] = err as []
+state228 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    68 -> state218 err (i:as) is
+    76 -> state220 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start229 :: Lexer
+start229 is = state229 (\ as is -> gotError as is) "" is
+state229 :: LexerState
+state229 err as [] = err as []
+state229 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    65 -> state218 err (i:as) is
+    76 -> state220 err (i:as) is
+    52 -> state230 err (i:as) is
+    56 -> state232 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start230 :: Lexer
+start230 is = state230 (\ as is -> gotError as is) "" is
+state230 :: LexerState
+state230 err as [] = err as []
+state230 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    69 -> state231 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start231 :: Lexer
+start231 is = state231 (\ as is -> gotError as is) "" is
+state231 :: LexerState
+state231 err as [] = err as []
+state231 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    52 -> state218 err (i:as) is
+    76 -> state220 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start232 :: Lexer
+start232 is = state232 (\ as is -> gotError as is) "" is
+state232 :: LexerState
+state232 err as [] = err as []
+state232 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    57 -> state233 err (i:as) is
+    67 -> state237 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start233 :: Lexer
+start233 is = state233 (\ as is -> gotError as is) "" is
+state233 :: LexerState
+state233 err as [] = err as []
+state233 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    52 -> state234 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start234 :: Lexer
+start234 is = state234 (\ as is -> gotError as is) "" is
+state234 :: LexerState
+state234 err as [] = err as []
+state234 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    70 -> state235 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start235 :: Lexer
+start235 is = state235 (\ as is -> gotError as is) "" is
+state235 :: LexerState
+state235 err as [] = err as []
+state235 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    62 -> state236 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start236 :: Lexer
+start236 is = state236 (\ as is -> gotError as is) "" is
+state236 :: LexerState
+state236 err as [] = err as []
+state236 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    69 -> state218 err (i:as) is
+    76 -> state220 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start237 :: Lexer
+start237 is = state237 (\ as is -> gotError as is) "" is
+state237 :: LexerState
+state237 err as [] = err as []
+state237 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    60 -> state238 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start238 :: Lexer
+start238 is = state238 (\ as is -> gotError as is) "" is
+state238 :: LexerState
+state238 err as [] = err as []
+state238 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    71 -> state239 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start239 :: Lexer
+start239 is = state239 (\ as is -> gotError as is) "" is
+state239 :: LexerState
+state239 err as [] = err as []
+state239 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    60 -> state240 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start240 :: Lexer
+start240 is = state240 (\ as is -> gotError as is) "" is
+state240 :: LexerState
+state240 err as [] = err as []
+state240 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    64 -> state241 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start241 :: Lexer
+start241 is = state241 (\ as is -> gotError as is) "" is
+state241 :: LexerState
+state241 err as [] = err as []
+state241 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    58 -> state218 err (i:as) is
+    76 -> state220 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start242 :: Lexer
+start242 is = state242 (\ as is -> gotError as is) "" is
+state242 :: LexerState
+state242 err as [] = err as []
+state242 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    62 -> state224 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start243 :: Lexer
+start243 is = state243 (\ as is -> gotError as is) "" is
+state243 :: LexerState
+state243 err as [] = err as []
+state243 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    57 -> state218 err (i:as) is
+    76 -> state220 err (i:as) is
+    63 -> state244 err (i:as) is
+    64 -> state247 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start244 :: Lexer
+start244 is = state244 (\ as is -> gotError as is) "" is
+state244 :: LexerState
+state244 err as [] = err as []
+state244 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    66 -> state245 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start245 :: Lexer
+start245 is = state245 (\ as is -> gotError as is) "" is
+state245 :: LexerState
+state245 err as [] = err as []
+state245 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    65 -> state246 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start246 :: Lexer
+start246 is = state246 (\ as is -> gotError as is) "" is
+state246 :: LexerState
+state246 err as [] = err as []
+state246 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    67 -> state236 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start247 :: Lexer
+start247 is = state247 (\ as is -> gotError as is) "" is
+state247 :: LexerState
+state247 err as [] = err as []
+state247 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    57 -> state248 err (i:as) is
+    68 -> state251 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start248 :: Lexer
+start248 is = state248 (\ as is -> gotError as is) "" is
+state248 :: LexerState
+state248 err as [] = err as []
+state248 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    60 -> state249 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start249 :: Lexer
+start249 is = state249 (\ as is -> gotError as is) "" is
+state249 :: LexerState
+state249 err as [] = err as []
+state249 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    73 -> state250 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start250 :: Lexer
+start250 is = state250 (\ as is -> gotError as is) "" is
+state250 :: LexerState
+state250 err as [] = err as []
+state250 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    62 -> state218 err (i:as) is
+    67 -> state218 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start251 :: Lexer
+start251 is = state251 (\ as is -> gotError as is) "" is
+state251 :: LexerState
+state251 err as [] = err as []
+state251 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    69 -> state252 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start252 :: Lexer
+start252 is = state252 (\ as is -> gotError as is) "" is
+state252 :: LexerState
+state252 err as [] = err as []
+state252 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    52 -> state253 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start253 :: Lexer
+start253 is = state253 (\ as is -> gotError as is) "" is
+state253 :: LexerState
+state253 err as [] = err as []
+state253 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    64 -> state254 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start254 :: Lexer
+start254 is = state254 (\ as is -> gotError as is) "" is
+state254 :: LexerState
+state254 err as [] = err as []
+state254 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    54 -> state225 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start255 :: Lexer
+start255 is = state255 (\ as is -> gotError as is) "" is
+state255 :: LexerState
+state255 err as [] = err as []
+state255 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    56 -> state236 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start256 :: Lexer
+start256 is = state256 (\ as is -> gotError as is) "" is
+state256 :: LexerState
+state256 err as [] = err as []
+state256 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    65 -> state257 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start257 :: Lexer
+start257 is = state257 (\ as is -> gotError as is) "" is
+state257 :: LexerState
+state257 err as [] = err as []
+state257 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    55 -> state258 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start258 :: Lexer
+start258 is = state258 (\ as is -> gotError as is) "" is
+state258 :: LexerState
+state258 err as [] = err as []
+state258 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    70 -> state259 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start259 :: Lexer
+start259 is = state259 (\ as is -> gotError as is) "" is
+state259 :: LexerState
+state259 err as [] = err as []
+state259 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    62 -> state225 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start260 :: Lexer
+start260 is = state260 (\ as is -> gotError as is) "" is
+state260 :: LexerState
+state260 err as [] = err as []
+state260 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    56 -> state261 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start261 :: Lexer
+start261 is = state261 (\ as is -> gotError as is) "" is
+state261 :: LexerState
+state261 err as [] = err as []
+state261 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    72 -> state262 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start262 :: Lexer
+start262 is = state262 (\ as is -> gotError as is) "" is
+state262 :: LexerState
+state262 err as [] = err as []
+state262 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    69 -> state263 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start263 :: Lexer
+start263 is = state263 (\ as is -> gotError as is) "" is
+state263 :: LexerState
+state263 err as [] = err as []
+state263 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    74 -> state264 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start264 :: Lexer
+start264 is = state264 (\ as is -> gotError as is) "" is
+state264 :: LexerState
+state264 err as [] = err as []
+state264 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    66 -> state225 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start265 :: Lexer
+start265 is = state265 (\ as is -> gotError as is) "" is
+state265 :: LexerState
+state265 err as [] = err as []
+state265 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    57 -> state218 err (i:as) is
+    76 -> state220 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start266 :: Lexer
+start266 is = state266 (\ as is -> gotError as is) "" is
+state266 :: LexerState
+state266 err as [] = err as []
+state266 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    74 -> state264 err (i:as) is
+    59 -> state267 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start267 :: Lexer
+start267 is = state267 (\ as is -> gotError as is) "" is
+state267 :: LexerState
+state267 err as [] = err as []
+state267 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    56 -> state268 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start268 :: Lexer
+start268 is = state268 (\ as is -> gotError as is) "" is
+state268 :: LexerState
+state268 err as [] = err as []
+state268 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    64 -> state218 err (i:as) is
+    76 -> state220 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start269 :: Lexer
+start269 is = state269 (\ as is -> gotError as is) "" is
+state269 :: LexerState
+state269 err as [] = err as []
+state269 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    59 -> state270 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start270 :: Lexer
+start270 is = state270 (\ as is -> gotError as is) "" is
+state270 :: LexerState
+state270 err as [] = err as []
+state270 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    56 -> state271 err (i:as) is
+    _ -> state219 err (i:as) is
+
+start271 :: Lexer
+start271 is = state271 (\ as is -> gotError as is) "" is
+state271 :: LexerState
+state271 err as [] = err as []
+state271 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    77 -> err as iis
+    76 -> state220 err (i:as) is
+    67 -> state225 err (i:as) is
+    _ -> state219 err (i:as) is
+
+state272 :: LexerState
+state272 err as [] = err as []
+  where err _ _ = output Reservedid as (start1 [])
+state272 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    _ -> state273 err (i:as) is
+  where err _ _ = output Reservedid as (start1 iis)
+
+state273 :: LexerState
+state273 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state273 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state274 :: LexerState
+state274 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state274 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    52 -> state275 err (i:as) is
+    62 -> state277 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state275 :: LexerState
+state275 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state275 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    68 -> state276 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state276 :: LexerState
+state276 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state276 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    56 -> state272 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state277 :: LexerState
+state277 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state277 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    52 -> state278 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state278 :: LexerState
+state278 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state278 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    68 -> state279 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state279 :: LexerState
+state279 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state279 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    68 -> state272 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state280 :: LexerState
+state280 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state280 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    65 -> state272 err (i:as) is
+    52 -> state281 err (i:as) is
+    56 -> state283 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state281 :: LexerState
+state281 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state281 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    69 -> state282 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state282 :: LexerState
+state282 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state282 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    52 -> state272 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state283 :: LexerState
+state283 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state283 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    57 -> state284 err (i:as) is
+    67 -> state288 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state284 :: LexerState
+state284 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state284 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    52 -> state285 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state285 :: LexerState
+state285 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state285 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    70 -> state286 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state286 :: LexerState
+state286 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state286 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    62 -> state287 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state287 :: LexerState
+state287 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state287 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    69 -> state272 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state288 :: LexerState
+state288 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state288 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    60 -> state289 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state289 :: LexerState
+state289 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state289 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    71 -> state290 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state290 :: LexerState
+state290 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state290 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    60 -> state291 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state291 :: LexerState
+state291 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state291 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    64 -> state292 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state292 :: LexerState
+state292 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state292 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    58 -> state272 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state293 :: LexerState
+state293 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state293 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    62 -> state275 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state294 :: LexerState
+state294 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state294 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    57 -> state272 err (i:as) is
+    63 -> state295 err (i:as) is
+    64 -> state298 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state295 :: LexerState
+state295 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state295 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    66 -> state296 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state296 :: LexerState
+state296 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state296 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    65 -> state297 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state297 :: LexerState
+state297 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state297 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    67 -> state287 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state298 :: LexerState
+state298 err as [] = err as []
+  where err _ _ = output Reservedid as (start1 [])
+state298 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    57 -> state299 err (i:as) is
+    68 -> state302 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Reservedid as (start1 iis)
+
+state299 :: LexerState
+state299 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state299 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    60 -> state300 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state300 :: LexerState
+state300 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state300 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    73 -> state301 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state301 :: LexerState
+state301 err as [] = err as []
+  where err _ _ = output Reservedid as (start1 [])
+state301 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    62 -> state272 err (i:as) is
+    67 -> state272 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Reservedid as (start1 iis)
+
+state302 :: LexerState
+state302 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state302 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    69 -> state303 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state303 :: LexerState
+state303 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state303 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    52 -> state304 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state304 :: LexerState
+state304 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state304 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    64 -> state305 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state305 :: LexerState
+state305 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state305 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    54 -> state276 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state306 :: LexerState
+state306 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state306 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    56 -> state287 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state307 :: LexerState
+state307 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state307 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    65 -> state308 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state308 :: LexerState
+state308 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state308 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    55 -> state309 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state309 :: LexerState
+state309 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state309 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    70 -> state310 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state310 :: LexerState
+state310 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state310 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    62 -> state276 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state311 :: LexerState
+state311 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state311 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    56 -> state312 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state312 :: LexerState
+state312 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state312 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    72 -> state313 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state313 :: LexerState
+state313 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state313 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    69 -> state314 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state314 :: LexerState
+state314 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state314 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    74 -> state315 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state315 :: LexerState
+state315 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state315 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    66 -> state276 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state316 :: LexerState
+state316 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state316 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    57 -> state272 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state317 :: LexerState
+state317 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state317 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    74 -> state315 err (i:as) is
+    59 -> state318 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state318 :: LexerState
+state318 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state318 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    56 -> state319 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state319 :: LexerState
+state319 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state319 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    64 -> state272 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state320 :: LexerState
+state320 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state320 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    59 -> state321 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state321 :: LexerState
+state321 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state321 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    56 -> state322 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state322 :: LexerState
+state322 err as [] = err as []
+  where err _ _ = output Varid as (start1 [])
+state322 err as iis@(i:is) =
+  case cclass i of
+    0 -> err as iis
+    1 -> err as iis
+    2 -> err as iis
+    3 -> err as iis
+    4 -> err as iis
+    5 -> err as iis
+    6 -> err as iis
+    7 -> err as iis
+    8 -> err as iis
+    9 -> err as iis
+    11 -> err as iis
+    12 -> err as iis
+    13 -> err as iis
+    14 -> err as iis
+    19 -> err as iis
+    20 -> err as iis
+    21 -> err as iis
+    22 -> err as iis
+    23 -> err as iis
+    47 -> err as iis
+    48 -> err as iis
+    49 -> err as iis
+    50 -> err as iis
+    75 -> err as iis
+    76 -> err as iis
+    77 -> err as iis
+    67 -> state276 err (i:as) is
+    _ -> state273 err (i:as) is
+  where err _ _ = output Varid as (start1 iis)
+
+state323 :: LexerState
+state323 err as [] = err as []
+  where err _ _ = output Special as (start1 [])
+state323 err as iis@(i:is) =
+  case cclass i of
+    13 -> state324 err (i:as) is
     _ -> err as iis
   where err _ _ = output Special as (start1 iis)
 
-state213 :: LexerState
-state213 err as is = nestedComment as is state214
+state324 :: LexerState
+state324 err as is = nestedComment as is state325
 
-state214 :: LexerState
-state214 err as is = output NestedComment as (start1 is)
+state325 :: LexerState
+state325 err as is = output NestedComment as (start1 is)
 
 

--- a/Language/Haskell/Lexer/Tokens.hs
+++ b/Language/Haskell/Lexer/Tokens.hs
@@ -19,6 +19,9 @@ data Token
   | Qvarsym     -- ^ Qualified variable operator
   | Qconsym     -- ^ Qualified constructor operator
 
+  | Quasiquote  -- ^ Quasi-quote
+  | Qquasiquote -- ^ Qualified quasi-quote
+
   | Special
   | Whitespace  -- ^ White space
 

--- a/bin/run-generator
+++ b/bin/run-generator
@@ -1,0 +1,4 @@
+#!/bin/sh -eu
+
+cd generator
+cabal v2-run -v0 > ../Language/Haskell/Lexer/Lex.hs

--- a/generator/src/Spec/HaskellLexicalSyntax.hs
+++ b/generator/src/Spec/HaskellLexicalSyntax.hs
@@ -33,6 +33,9 @@ lexeme  = varid      & o Varid
         ! qvarsym    & o Qvarsym
         ! qconsym    & o Qconsym
 
+        ! quasiquote  & o Quasiquote
+        ! qquasiquote & o Qquasiquote
+
 literal = integer    & o IntLit
         ! float      & o FloatLit
         ! char       & o CharLit
@@ -77,6 +80,9 @@ specialid = as"as" ! as"qualified" ! as"hiding"
 
 varsym = (a symbol & many (a symbol ! aa ":")) -! (reservedop ! dashes)
 consym = (aa ":" & many (a symbol ! aa ":")) -! reservedop
+
+quasiquote = aa "[" & varid & aa "|" & many (a cany ! whitechar) & aa "|]"
+qquasiquote = aa "[" & qvarid & aa "|" & many (a cany ! whitechar) & aa "|]"
 
 reservedop = ass ["..", ":","::", "=","\\","|","<-","->","@","~","=>"]
 


### PR DESCRIPTION
This adds lexing of quasi-quotes in a similar way to the [GHC Lexer](https://github.com/ghc/ghc/blob/master/compiler/parser/Lexer.x#L381-L384).

One difference is that here we aren't providing the breakdown into quoter+quote, the whole thing is lexed as a single token. This won't be a problem for me to do what I want `pretty-show`, but happy to change that if you like. I'm wasn't sure what tokens broken down to quoter+quote would look like in this library.

I added a script to `bin/run-generator` to build and run the generator, hope that's useful.

I didn't add the other kinds of quotes which are available (exp,texp,etc) as I don't need them and they would create a bunch more tokens. I'm happy to do it for completeness though if you would prefer that.

I couldn't see how to easily make all this optional.