### PR TITLE
Disable unused-top-binds warning; bump CI to latest GHCs

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20220710
+# version: 0.15.20230115
 #
-# REGENDATA ("0.15.20220710",["github","haskell-lexer.cabal"])
+# REGENDATA ("0.15.20230115",["github","haskell-lexer.cabal"])
 #
 name: Haskell-CI
 on:
@@ -34,14 +34,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.4.0.20220623
+          - compiler: ghc-9.6.0.20230111
             compilerKind: ghc
-            compilerVersion: 9.4.0.20220623
+            compilerVersion: 9.6.0.20230111
             setup-method: ghcup
             allow-failure: true
-          - compiler: ghc-9.2.3
+          - compiler: ghc-9.4.4
             compilerKind: ghc
-            compilerVersion: 9.2.3
+            compilerVersion: 9.4.4
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.5
+            compilerKind: ghc
+            compilerVersion: 9.2.5
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -117,7 +122,7 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.8/x86_64-linux-ghcup-0.1.17.8 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
@@ -127,7 +132,7 @@ jobs:
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.8/x86_64-linux-ghcup-0.1.17.8 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
@@ -160,7 +165,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          if [ $((HCNUMVER >= 90600)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -224,7 +229,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -263,7 +268,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
       - name: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store

--- a/haskell-lexer.cabal
+++ b/haskell-lexer.cabal
@@ -14,8 +14,9 @@ Homepage:            https://github.com/yav/haskell-lexer
 Bug-reports:         https://github.com/yav/haskell-lexer/issues
 
 tested-with:
-  GHC == 9.4.1
-  GHC == 9.2.3
+  GHC == 9.6.0
+  GHC == 9.4.4
+  GHC == 9.2.5
   GHC == 9.0.2
   GHC == 8.10.7
   GHC == 8.8.4
@@ -47,6 +48,7 @@ Library
   if impl(GHC >= 8.0)
     GHC-options:
       -Wcompat
+      -Wno-unused-top-binds
 
   default-language: Haskell2010
 


### PR DESCRIPTION
During build, there are still 221 warnings produced of the form:
```
Language/Haskell/Lexer/Lex.hs:5521:1: warning: [-Wunused-top-binds]
    Defined but not used: ‘start221’
     |
5521 | start221 is = state221 (\ as is -> gotError as is) "" is
     | ^^^^^^^^
```
This PR switches off `-Wunused-top-binds` and bumps CI to latest GHCs.