### PR TITLE
 Implement GHC's relaxed rules for unicode symbols 

### DIFF
--- a/Language/Haskell/Lexer/Lex.hs
+++ b/Language/Haskell/Lexer/Lex.hs
@@ -122,9 +122,10 @@ cclass c =
     c | isAscii c -> 0
       | isSpace c -> 3
       | (\x -> isSymbol x || isPunctuation x) c -> 7
-      | isDigit c -> 18
-      | isLower c -> 61
+      | (\x -> case generalCategory x of DecimalNumber -> True; LetterNumber -> True; OtherNumber -> True; _ -> False) c -> 18
+      | (\x -> isLower x || generalCategory x == OtherLetter) c -> 61
       | isUpper c -> 78
+      | (\x -> case generalCategory x of ModifierLetter -> True; NonSpacingMark -> True; _ -> False) c -> 79
       | otherwise -> 0
 
 start1 :: Lexer
@@ -164,9 +165,10 @@ state1 err as iis@(i:is) =
     16 -> state87 err (i:as) is
     17 -> state87 err (i:as) is
     18 -> state87 err (i:as) is
+    0 -> err as iis
+    79 -> err as iis
     11 -> state73 err (i:as) is
     49 -> state73 err (i:as) is
-    0 -> err as iis
     8 -> state5 err (i:as) is
     10 -> state41 err (i:as) is
     13 -> state74 err (i:as) is
@@ -238,6 +240,7 @@ state5 err as iis@(i:is) =
     3 -> err as iis
     4 -> err as iis
     5 -> err as iis
+    79 -> err as iis
     8 -> state6 err (i:as) is
     48 -> state7 err (i:as) is
     _ -> state5 err (i:as) is
@@ -318,6 +321,7 @@ state10 err as iis@(i:is) =
     3 -> err as iis
     4 -> err as iis
     5 -> err as iis
+    79 -> err as iis
     15 -> state10 err (i:as) is
     16 -> state10 err (i:as) is
     17 -> state10 err (i:as) is
@@ -590,6 +594,7 @@ state36 err as iis@(i:is) =
     3 -> err as iis
     4 -> err as iis
     5 -> err as iis
+    79 -> err as iis
     15 -> state36 err (i:as) is
     16 -> state36 err (i:as) is
     17 -> state36 err (i:as) is
@@ -649,6 +654,7 @@ state39 err as iis@(i:is) =
     3 -> err as iis
     4 -> err as iis
     5 -> err as iis
+    79 -> err as iis
     8 -> state6 err (i:as) is
     48 -> state7 err (i:as) is
     _ -> state5 err (i:as) is
@@ -666,6 +672,7 @@ state41 err as iis@(i:is) =
     4 -> err as iis
     5 -> err as iis
     10 -> err as iis
+    79 -> err as iis
     48 -> state44 err (i:as) is
     _ -> state42 err (i:as) is
 
@@ -1112,6 +1119,7 @@ state76 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
     3 -> err as iis
+    79 -> err as iis
     2 -> state77 err (i:as) is
     4 -> state77 err (i:as) is
     5 -> state78 err (i:as) is
@@ -1504,6 +1512,7 @@ state98 err as iis@(i:is) =
     47 -> err as iis
     49 -> err as iis
     75 -> err as iis
+    79 -> err as iis
     52 -> state111 err (i:as) is
     53 -> state111 err (i:as) is
     57 -> state111 err (i:as) is
@@ -3811,6 +3820,7 @@ state166 err as [] = err as []
 state166 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
+    79 -> err as iis
     76 -> state169 err (i:as) is
     _ -> state166 err (i:as) is
 
@@ -3821,6 +3831,7 @@ state169 err as [] = err as []
 state169 err as iis@(i:is) =
   case cclass i of
     0 -> err as iis
+    79 -> err as iis
     76 -> state169 err (i:as) is
     49 -> state172 err (i:as) is
     _ -> state166 err (i:as) is

--- a/generator/src/DetMachineToHaskell.hs
+++ b/generator/src/DetMachineToHaskell.hs
@@ -184,9 +184,10 @@ haskellCharCase e rhs defaultrhs cases =
       case u of
         UniWhite -> "isSpace"
         UniSymbol -> "(\\x -> isSymbol x || isPunctuation x)"
-        UniDigit -> "isDigit"
+        UniDigit -> "(\\x -> case generalCategory x of DecimalNumber -> True; LetterNumber -> True; OtherNumber -> True; _ -> False)"
         UniLarge -> "isUpper"
-        UniSmall -> "isLower"
+        UniSmall -> "(\\x -> isLower x || generalCategory x == OtherLetter)"
+        UniIdchar -> "(\\x -> case generalCategory x of ModifierLetter -> True; NonSpacingMark -> True; _ -> False)"
         ASCII _  -> error "tstFunc applied to an ASCII char"
 
 instance CaseOf Int where caseExp = simpleCase; errorValue=Just 0

--- a/generator/src/Spec/HaskellChars.hs
+++ b/generator/src/Spec/HaskellChars.hs
@@ -3,6 +3,10 @@ This module collects the definitions from the Lexical Syntax in appendix B.3
 of the (revised) Haskell 98 report that define sets of characters.
 These sets are referred to in the rest of the lexical syntax,
 which is given in module HaskellLexicalSyntax.
+
+A deviation is the more relaxed handling of certain unicode characters as in
+GHC, see https://downloads.haskell.org/ghc/9.12.1/docs/users_guide/bugs.html for
+details.
 -}
 
 module Spec.HaskellChars where
@@ -16,9 +20,10 @@ data HaskellChar
   = ASCII Char
   | UniWhite   -- any Unicode character defined as whitespace
   | UniSymbol  -- any Unicode symbol or punctuation
-  | UniDigit   -- any Unicode numeric
+  | UniDigit   -- any Unicode Decimal Number, Letter Number or Other Number
   | UniLarge   -- any uppercase or titlecase Unicode letter
-  | UniSmall   -- any Unicode lowercase letter
+  | UniSmall   -- any Unicode Lowercase Letter or Other Letter
+  | UniIdchar  -- any Unicode Modifier Letter or Non-Spacing Mark
   deriving (Eq,Ord{-,Show-})
 
 acs = map ASCII
@@ -48,6 +53,7 @@ ascDigit  = acs ['0'..'9']
 uniDigit  = [UniDigit]
 octit     = acs ['0'..'7']
 hexit     = digit ++ acs ['A'..'F'] ++ acs ['a'..'f']
+uniIdchar = [UniIdchar]
 
 ----
 

--- a/generator/src/Spec/HaskellLexicalSyntax.hs
+++ b/generator/src/Spec/HaskellLexicalSyntax.hs
@@ -73,7 +73,7 @@ qquote = start & body
 
 varid = a small & idtail -! reservedid
 conid = a large & idtail
-idtail = many (a small ! a large ! a digit ! aa "'")
+idtail = many (a small ! a large ! a digit ! a uniIdchar ! aa "'")
 
 reservedid =
   ass [ "case", "class", "data", "default", "deriving", "do", "else",


### PR DESCRIPTION
Closes #14

From https://downloads.haskell.org/ghc/9.12.1/docs/users_guide/bugs.html:

> GHC is more lenient in which characters are allowed in the identifiers. Unicode Other Letters are considered to be small letters, therefore variable identifiers can begin with them. Digit class contains all Unicode numbers instead of just Decimal Numbers. Modifier Letters and Non-Spacing Marks can appear in the tail of the identifiers.:
>
> ```
> uniSmall    →   any Unicode Lowercase Letter or Other Letter
> uniDigit    →   any Unicode Decimal Number, Letter Number or Other Number
> 
> uniIdchar   →   any Unicode Modifier Letter or Non-Spacing Mark
> idchar      →   small | large | digit | uniIdchar | '
> 
> varid       →   small {idchar} ⟨reservedid⟩
> conid       →   large {idchar}
> ```

